### PR TITLE
fixed a bug: wrong edges in graphalytics import if smartgraph

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -33,7 +33,7 @@ def make_database_parameters(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--overwrite', action='store_true',  # default: false
                         help='Overwrite the graph and the collection if they already exist.')
     parser.add_argument('--make_smart', action='store_true',  # default: false
-                        help='Create a smart graph.')
+                        help='Create a smart graph (ignored for benchmarking with Pregel).')
 
 
 def make_general_graph_parameters_generator(parser: argparse.ArgumentParser) -> None:
@@ -128,3 +128,29 @@ def make_pregel_parameters(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--useMemoryMaps', action='store_true',  # default: False
                         help='Whether to use disk based files to store temporary results.')
     parser.add_argument('--shardKeyAttribute', help='The shard key that edge collections are sharded after.')
+    parser.add_argument('algorithm', help='''The name of the Gregel algorithm, one of:
+                                                        pagerank - Page Rank; 
+                                                        sssp - Single-Source Shortest Path; 
+                                                        connectedcomponents - Connected Components;
+                                                        wcc - Weakly Connected Components;
+                                                        scc - Strongly Connected Components;
+                                                        hits - Hyperlink-Induced Topic Search;
+                                                        effectivecloseness - Effective Closeness;
+                                                        linerank - LineRank;
+                                                        labelpropagation - Label Propagation;
+                                                        slpa - Speaker-Listener Label Propagation''',
+                        choices=['pagerank', 'sssp', 'connectedcomponents', 'wcc', 'scc', 'hits', 'effectivecloseness',
+                                 'linerank', 'labelpropagation', 'slpa'])
+    # pagerank
+    parser.add_argument('--pr_threshold', type=float,
+                        help='If \'algorithm\' is \'pagerank\', execute until the value changes in the vertices '
+                             'are at most pr_threshold. Otherwise ignored.')
+    parser.add_argument('--pr_sourceField', type=str,
+                        help='If \'algorithm\' is \'pagerank\', the attribute of vertices to read the initial '
+                             'rank value from. Otherwise ignored.')
+
+    # sssp
+    parser.add_argument('--sssp_source', help='If \'algorithm\' is \'sssp\', the vertex ID to calculate distances.'
+                                              ' Otherwise ignored.')
+    parser.add_argument('--sssp_resultField', help='If \'algorithm\' is \'pagerank\', the vertex ID to calculate '
+                                                   'distance. Otherwise ignored.')

--- a/edges_generator.py
+++ b/edges_generator.py
@@ -96,9 +96,9 @@ def get_edge_property(a) -> Union[None, VertexOrEdgeProperty]:
         return VertexOrEdgeProperty('list', val_list=list(a.edge_property))
 
 
-def make_edges_connect_parts(clique_helper: CliquesHelper, bulk_size_: int, prob_missing_all: float, prob_missing_one: float,
-                             db_info: DatabaseInfo, graph_info: GraphInfo, start_from_idx: int, end_from_idx: int,
-                             be_verbose: bool = True) -> Iterable:
+def make_edges_connect_parts(clique_helper: CliquesHelper, bulk_size_: int, prob_missing_all: float,
+                             prob_missing_one: float, db_info: DatabaseInfo, graph_info: GraphInfo, start_from_idx: int,
+                             end_from_idx: int, be_verbose: bool = True) -> Iterable:
     """
     Given a list parts of disjoint vertex sets (disjointness is not verified), connect every vertex of every part
     with every vertex of every other part.

--- a/general.py
+++ b/general.py
@@ -45,7 +45,6 @@ def get_all_collections(db_info: DatabaseInfo):
     return [c['name'] for c in collections]
 
 
-# todo correct all calls to check overwriting
 def create_graph(db_info: DatabaseInfo):
     """
     Create a new smart graph with vertices v_coll and edges edge_coll_name with given parameters.

--- a/generator.py
+++ b/generator.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import cProfile
 import time
 
 from arguments import make_database_parameters, make_general_graph_parameters_generator, make_cliques_graph_parameters
@@ -43,7 +42,6 @@ def get_arguments():
 if __name__ == "__main__":
     if not arangodIsRunning():
         raise RuntimeError('The process \'arangod\' is not running, please, run it first.')
-
 
     args = get_arguments()
 

--- a/graphalytics_importer.py
+++ b/graphalytics_importer.py
@@ -125,7 +125,7 @@ def read_and_create_edges_graphalytics(edges_filename, properties_filename, db_i
 
     num_edges = get_property_graphalytics(properties_filename, 'num_edges')
     print(f'Number of edges: {num_edges}')
-    to_v = ConverterToVertex(db_info.vertices_coll_name).idx_to_vertex
+    to_v = ConverterToVertex(db_info.vertices_coll_name).idx_to_smart_vertex
 
     start_e = time.monotonic()
     if be_verbose:

--- a/k_partite_generator.py
+++ b/k_partite_generator.py
@@ -35,6 +35,6 @@ def create_k_partite_graph(db_info: DatabaseInfo,
         make_and_insert_vertices(db_info, graph_info, size, bulk_size, add_part=True, c_helper=c_helper)
 
     # create edges between cliques
-
+    # todo finish making parallel
     for edges in make_edges_connect_parts(c_helper, bulk_size, 0.0, 0.0, db_info, graph_info, be_verbose):
         insert_documents(db_info, edges, db_info.edge_coll_name)

--- a/start_Pregel.py
+++ b/start_Pregel.py
@@ -22,36 +22,7 @@ def get_arguments():
     make_database_input_parameters(parser)
     make_pregel_parameters(parser)
 
-    # pagerank
-    parser.add_argument('algorithm', help='''The name of the Gregel algorithm, one of:
-                                                        pagerank - Page Rank; 
-                                                        sssp - Single-Source Shortest Path; 
-                                                        connectedcomponents - Connected Components;
-                                                        wcc - Weakly Connected Components;
-                                                        scc - Strongly Connected Components;
-                                                        hits - Hyperlink-Induced Topic Search;
-                                                        effectivecloseness - Effective Closeness;
-                                                        linerank - LineRank;
-                                                        labelpropagation - Label Propagation;
-                                                        slpa - Speaker-Listener Label Propagation''',
-                        choices=['pagerank', 'sssp', 'connectedcomponents', 'wcc', 'scc', 'hits', 'effectivecloseness',
-                                 'linerank', 'labelpropagation', 'slpa'])
-
-    parser.add_argument('--pr_threshold', type=float,
-                        help='If \'algorithm\' is \'pagerank\', execute until the value changes in the vertices '
-                             'are at most pr_threshold. Otherwise ignored.')
-    parser.add_argument('--pr_sourceField', type=str,
-                        help='If \'algorithm\' is \'pagerank\', the attribute of vertices to read the initial '
-                             'rank value from. Otherwise ignored.')
-
-    # sssp
-    parser.add_argument('--sssp_source', help='If \'algorithm\' is \'sssp\', the vertex ID to calculate distances.'
-                                              ' Otherwise ignored.')
-    parser.add_argument('--sssp_resultField', help='If \'algorithm\' is \'pagerank\', the vertex ID to calculate '
-                                                   'distance. Otherwise ignored.')
-
     arguments = parser.parse_args()
-
     return arguments
 
 

--- a/vertices_generator.py
+++ b/vertices_generator.py
@@ -1,6 +1,6 @@
 import os
 import random
-from typing import Union
+from typing import Union, Optional
 
 import requests
 import tqdm
@@ -150,8 +150,11 @@ class ConverterToVertex:
     def __init__(self, vertex_coll_name: str):
         self.vertex_coll_name = vertex_coll_name
 
-    def idx_to_smart_vertex(self, idx: Union[int, str], smart_value: str) -> str:
-        return f"{self.vertex_coll_name}/{smart_value}:{idx}"
+    def idx_to_smart_vertex(self, idx: Union[int, str], smart_value: Optional[str] = None) -> str:
+        if smart_value:
+            return f'{self.vertex_coll_name}/{smart_value}:{idx}'
+        else:
+            return f'{self.vertex_coll_name}/{idx}:{idx}'
 
     def idx_to_vertex(self, idx: Union[int, str]):
         return f"{self.vertex_coll_name}/{idx}"


### PR DESCRIPTION
The important changes are in `graphalytics_importer.py:128` and in `vertices_generator.py:153-157`.

The bug was in always making non-smart edges. In `read_and_create_edges_graphalytics()` the function translating an id to a representation suitable for using in edge creation was set to `ConverterToVertex(db_info.vertices_coll_name).idx_to_vertex`, now changed to `ConverterToVertex(db_info.vertices_coll_name).idx_to_smart_vertex`. Also `idx_to_smart_vertex` can now accept a single parameter `idx` without `smart_attribute` , which is then set to `idx`. This probably makes the import slightly slower (an additional if-check for each edge), but otherwise the code would be duplicated for the smart case.

Also refactored script arguments: replaced direct adding of arguments by calling general functions from `arguments.py`.